### PR TITLE
add Dockerfile for dockerhub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM solr:6.6
+LABEL maintainer="University of Alberta Libraries"
+COPY ./solr/blacklight-core/conf /myconfig
+COPY ./solr/lib /opt/solr/lib
+CMD ["solr-precreate", "discovery", "/myconfig"]

--- a/README.md
+++ b/README.md
@@ -35,3 +35,55 @@ But be aware: Discovery suffers revisions much more frequently, than this repo. 
 Why a separate repo?
 At the inception of the Discovery project, the files inside this repo were buried within the Discovery repo. Neil split them out, 
 to facilitate RPM-based distribution.  And to prevent Sam from accidentally updating the schema, without telling me.
+
+# Docker image for UAL Discovery/NEOS Discovery Solr
+
+
+## What is this?
+
+This image can be used as a Solr datastore for [UAL Discovery](https://github.com/ualbertalib/discovery) and [NEOS Discovery](https://github.com/ualbertalib/neosdiscovery). This image is built on the [Solr 6.6 image](https://hub.docker.com/_/solr/) and adds the configuration files required to create collections. This is necessary because the configuration lives in a seperate repository to the application.
+
+## Requirements
+
+
+Ensure you have [Docker (1.13.0+)](https://docs.docker.com/engine/installation/) and 
+[Docker Compose (1.10.0+)](https://docs.docker.com/compose/install/) installed
+
+
+## In this Docker Container
+
+In the Docker Container are the minimum dependencies to run Solr with this projects schema and configurations available in the /myconfig directory.
+
+
+## Usage
+
+Expected usage is with Docker Compose `docker-compose up -d` which can use the entrypoints
+provided by the solr container to create any collections
+desired (discovery_test, etc).
+
+[Developer Handbook Docker Usage Section](https://github.com/ualbertalib/Developer-Handbook/tree/master/Docker#docker-usage)
+
+### Updating Docker Hub
+
+* Image will be updated using hooks upon merge to the master branch of [this project](https://github.com/ualbertalib/blacklight_solr_conf)
+* Find us on [Docker Hub](https://hub.docker.com/r/ualbertalib/blacklight_solr_conf/)
+
+### Upgrading local container
+
+Expected usage is with Docker Compose `docker-compose pull` which will seek out the latest
+image from Docker Hub.
+
+See [Developer Handbook Updating the local container](https://github.com/ualbertalib/Developer-Handbook/tree/master/Docker#updating-local-container)
+
+## Frequently used commands
+
+See [Developer Handbook](https://github.com/ualbertalib/Developer-Handbook/tree/master/Docker#frequently-used-commands)
+
+## Special notes / warnings / gotchas
+
+
+
+
+## Future considerations
+
+To capture any proposed future work or future considerations.


### PR DESCRIPTION
This image can be used as a Solr datastore for [UAL Discovery](https://github.com/ualbertalib/discovery) and [NEOS Discovery](https://github.com/ualbertalib/neosdiscovery). This image is built on the [Solr 6.6 image](https://hub.docker.com/_/solr/) and adds the configuration files required to create collections. This is necessary because the configuration lives in a separate repository to the application.