### PR TITLE
prioritize precision by ensuring more clauses are matched

### DIFF
--- a/solr/blacklight-core/conf/solrconfig.xml
+++ b/solr/blacklight-core/conf/solrconfig.xml
@@ -98,7 +98,7 @@
        <int name="rows">10</int>
 
        <str name="q.alt">*:*</str>
-       <str name="mm">2&lt;-1 5&lt;-2 6&lt;90%</str>
+       <str name="mm">6&lt;90%</str>
 
        <!-- this qf and pf are used by default, if not otherwise specified by
             client. The default blacklight_config will use these for the


### PR DESCRIPTION
This is what we've currently configured `<str name="mm">2&lt;-1 5&lt;-2 6&lt;90%</str>`

mm is Minimum Should Match

If there are 1 or 2 clauses, then both are required.
2<-1
If there is 3, 4 or 5 clauses then all but one is required.
5<-2
If there is 6 clauses then all but two is required.
6<90%
If there are more than 6 clauses then 90% are required.

So for these queries, british missions south pacific (319) has four clauses, three are required. And for british missions "south pacific" (1,358) has three clauses, two are required. (You can see this in the debugged query where ~2 vs ~3 slop is used).

We can simplify this to increase precision.  One side-effect of this change might be that there are queries that return zero results that previously returned many.